### PR TITLE
Add feature to clear cookies

### DIFF
--- a/apps/expo-go/src/menu/DevMenuView.tsx
+++ b/apps/expo-go/src/menu/DevMenuView.tsx
@@ -12,6 +12,8 @@ import * as DevMenu from './DevMenuModule';
 import { DevMenuOnboarding } from './DevMenuOnboarding';
 import { DevMenuServerInfo } from './DevMenuServerInfo';
 import { DevMenuTaskInfo } from './DevMenuTaskInfo';
+import SessionActions from '../redux/SessionActions';
+import { useDispatch } from '../redux/Hooks';
 
 type Props = {
   task: { manifestUrl: string; manifestString: string };
@@ -49,6 +51,7 @@ const MENU_ITEMS_ICON_MAPPINGS: {
 
 export function DevMenuView({ uuid, task }: Props) {
   const context = useContext(DevMenuBottomSheetContext);
+  const dispatch = useDispatch();
 
   const [enableDevMenuTools, setEnableDevMenuTools] = React.useState(false);
   const [devMenuItems, setDevMenuItems] = React.useState<{ [key: string]: any }>({});
@@ -131,6 +134,10 @@ export function DevMenuView({ uuid, task }: Props) {
     DevMenu.goToHomeAsync();
   }
 
+  function onClearCookies() {
+    dispatch(SessionActions.clearCookies());
+  }
+
   function onPressDevMenuButton(key: string) {
     DevMenu.selectItemWithKeyAsync(key);
   }
@@ -173,6 +180,13 @@ export function DevMenuView({ uuid, task }: Props) {
                   label="Go Home"
                   onPress={onGoToHome}
                   icon={<HomeFilledIcon size={iconSize.small} color={theme.icon.default} />}
+                />
+                <Divider />
+                <DevMenuItem
+                  buttonKey="clearCookies"
+                  label="Clear Cookies"
+                  onPress={onClearCookies}
+                  icon={<ThemedMaterialIcon name="cookie" />}
                 />
               </View>
             </View>

--- a/apps/expo-go/src/redux/SessionActions.ts
+++ b/apps/expo-go/src/redux/SessionActions.ts
@@ -38,4 +38,24 @@ export default {
       });
     };
   },
+
+  clearCookies(): AppThunk {
+    return async (dispatch: AppDispatch) => {
+      try {
+        // Clear all cookies and stored data
+        await LocalStorage.clearCookiesAsync();
+        
+        // Reset Apollo client store
+        ApolloClient.resetStore();
+
+        return dispatch({
+          type: 'clearCookies',
+          payload: null,
+        });
+      } catch (e) {
+        console.error('Something went wrong when clearing cookies:', e);
+        throw e;
+      }
+    };
+  },
 };

--- a/apps/expo-go/src/redux/SessionReducer.ts
+++ b/apps/expo-go/src/redux/SessionReducer.ts
@@ -15,13 +15,16 @@ type SessionActions =
       type: 'setSession';
       payload: SessionObject;
     }
-  | { type: 'signOut' };
+  | { type: 'signOut' }
+  | { type: 'clearCookies' };
 
 export default (state: SessionType = new SessionState(), action: SessionActions): SessionType => {
   switch (action.type) {
     case 'setSession':
       return new SessionState(action.payload);
     case 'signOut':
+      return new SessionState();
+    case 'clearCookies':
       return new SessionState();
     default:
       return state;

--- a/apps/expo-go/src/storage/LocalStorage.ts
+++ b/apps/expo-go/src/storage/LocalStorage.ts
@@ -84,6 +84,20 @@ async function clearHistoryAsync(): Promise<void> {
   await AsyncStorage.removeItem(Keys.History);
 }
 
+async function clearCookiesAsync(): Promise<void> {
+  // Clear all AsyncStorage data related to the app
+  await AsyncStorage.multiRemove([Keys.Settings, Keys.History]);
+  
+  // Clear session data through Kernel
+  await Kernel.removeSessionAsync();
+  
+  // Clear any additional stored data
+  await AsyncStorage.removeItem('currentAccount');
+  await AsyncStorage.removeItem('userReviewInfo');
+  await AsyncStorage.removeItem('@@expo@@:onboarding');
+  await AsyncStorage.removeItem('@@expo@@:session');
+}
+
 async function removeSessionAsync(): Promise<void> {
   await Kernel.removeSessionAsync();
 }
@@ -117,6 +131,7 @@ addListenerWithNativeCallback('ExponentKernel.getHistoryUrlForExperienceId', asy
 
 export default {
   clearHistoryAsync,
+  clearCookiesAsync,
   getSessionAsync,
   getHistoryAsync,
   getSettingsAsync,


### PR DESCRIPTION
Add a "Clear Cookies" feature to the developer menu to allow users to reset stored app data.

This feature provides users with control over their stored data, aids in development/testing, and helps with troubleshooting issues related to cached or corrupted data by clearing session, history, settings, account, and cached information.