### PR TITLE
Add feature to clear cookies

### DIFF
--- a/apps/expo-go/modules/react-native-webview/CHANGES_SUMMARY.md
+++ b/apps/expo-go/modules/react-native-webview/CHANGES_SUMMARY.md
@@ -1,0 +1,81 @@
+# Clear Cookies Feature Implementation Summary
+
+This document summarizes all the changes made to implement the `clearCookies` feature in React Native WebView.
+
+## Files Modified
+
+### 1. TypeScript Types
+**File:** `src/WebViewTypes.ts`
+- Added `'clearCookies'` to the `WebViewCommands` type union
+
+### 2. Android Implementation
+**File:** `android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt`
+- Added `COMMAND_CLEAR_COOKIES = 1003` constant
+- Added `"clearCookies"` to the commands map
+- Added implementation in `receiveCommand` method using `CookieManager.removeAllCookies()` and `CookieManager.flush()`
+
+**File:** `src/WebView.android.tsx`
+- Added `clearCookies` method to the `useImperativeHandle` hook
+
+### 3. iOS Implementation
+**File:** `apple/RNCWebViewImpl.m`
+- Added `clearCookies` method that handles both iOS 11+ (using `WKHTTPCookieStore`) and older versions (using `NSHTTPCookieStorage`)
+
+**File:** `src/WebView.ios.tsx`
+- Added `clearCookies` method to the `useImperativeHandle` hook
+
+### 4. macOS Implementation
+**File:** `src/WebView.macos.tsx`
+- Added `clearCookies` method to the `useImperativeHandle` hook (uses same native implementation as iOS)
+
+### 5. Windows Implementation
+**File:** `windows/ReactNativeWebView/ReactWebView2Manager.cpp`
+- Added `"clearCookies"` to the commands list
+- Added implementation in `DispatchCommand` method using `CoreWebView2.CookieManager.DeleteAllCookies()`
+
+**File:** `src/WebView.windows.tsx`
+- Added `"clearCookies"` to the supported commands list
+- Added `clearCookies` method to the `useImperativeHandle` hook
+
+## New Files Created
+
+### Documentation
+**File:** `CLEAR_COOKIES_FEATURE.md`
+- Comprehensive documentation for the new feature including usage examples, platform support, and implementation details
+
+**File:** `CHANGES_SUMMARY.md`
+- This summary document
+
+## Feature Overview
+
+The `clearCookies` feature provides a consistent API across all platforms to clear all cookies from a WebView instance. The implementation:
+
+1. **Follows existing patterns** - Uses the same command structure as `clearCache` and `clearHistory`
+2. **Platform-specific implementations** - Each platform uses its native cookie management APIs
+3. **Backward compatibility** - iOS implementation includes fallback for older iOS versions
+4. **Type safety** - Properly typed in TypeScript
+5. **Consistent API** - Same method signature across all platforms
+
+## Usage
+
+```javascript
+// Get a ref to the WebView
+const webViewRef = useRef(null);
+
+// Clear cookies
+webViewRef.current.clearCookies();
+```
+
+## Testing
+
+The feature can be tested by:
+1. Loading a website that sets cookies
+2. Calling `webViewRef.current.clearCookies()`
+3. Verifying that cookies are cleared (e.g., by checking browser developer tools or reloading the page)
+
+## Platform Support
+
+- ✅ Android (API level 21+)
+- ✅ iOS (iOS 8+)
+- ✅ macOS (macOS 10.10+)
+- ✅ Windows (Windows 10+ with WebView2)

--- a/apps/expo-go/modules/react-native-webview/CLEAR_COOKIES_FEATURE.md
+++ b/apps/expo-go/modules/react-native-webview/CLEAR_COOKIES_FEATURE.md
@@ -1,0 +1,89 @@
+# Clear Cookies Feature
+
+This document describes the new `clearCookies` feature added to React Native WebView.
+
+## Overview
+
+The `clearCookies` method allows you to programmatically clear all cookies from the WebView. This is useful for privacy, testing, or when you need to reset the WebView's cookie state.
+
+## Usage
+
+```javascript
+import React, { useRef } from 'react';
+import { View, Button } from 'react-native';
+import WebView from 'react-native-webview';
+
+const MyComponent = () => {
+  const webViewRef = useRef(null);
+
+  const handleClearCookies = () => {
+    if (webViewRef.current) {
+      webViewRef.current.clearCookies();
+    }
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Button title="Clear Cookies" onPress={handleClearCookies} />
+      <WebView
+        ref={webViewRef}
+        source={{ uri: 'https://example.com' }}
+        style={{ flex: 1 }}
+      />
+    </View>
+  );
+};
+```
+
+## Platform Support
+
+The `clearCookies` method is supported on all platforms:
+
+- **Android**: Uses `CookieManager.removeAllCookies()` and `CookieManager.flush()`
+- **iOS**: Uses `WKHTTPCookieStore.deleteCookie()` for iOS 11+ and `NSHTTPCookieStorage.deleteCookie()` for older versions
+- **macOS**: Uses the same implementation as iOS
+- **Windows**: Uses `CoreWebView2.CookieManager.DeleteAllCookies()`
+
+## API Reference
+
+### clearCookies()
+
+Clears all cookies from the WebView.
+
+**Parameters:** None
+
+**Returns:** void
+
+**Example:**
+```javascript
+webViewRef.current.clearCookies();
+```
+
+## Implementation Details
+
+### Android
+- Uses Android's `CookieManager` API
+- Calls `removeAllCookies(null)` to remove all cookies
+- Calls `flush()` to ensure changes are persisted
+
+### iOS/macOS
+- For iOS 11+: Uses `WKHTTPCookieStore` to get all cookies and delete them individually
+- For iOS < 11: Uses `NSHTTPCookieStorage` as a fallback
+- Handles both shared and private cookie stores
+
+### Windows
+- Uses WebView2's `CoreWebView2.CookieManager.DeleteAllCookies()` method
+- Clears all cookies from the WebView2 instance
+
+## Related Methods
+
+- `clearCache(includeDiskFiles)`: Clears the WebView cache
+- `clearHistory()`: Clears the WebView navigation history
+- `clearFormData()`: Clears form data (Android only)
+
+## Notes
+
+- The method is asynchronous on some platforms but the API is synchronous for consistency
+- Cookies are cleared immediately when the method is called
+- This affects all cookies for all domains in the WebView
+- The method is safe to call multiple times

--- a/apps/expo-go/modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/apps/expo-go/modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -296,6 +296,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
     val COMMAND_CLEAR_FORM_DATA = 1000
     val COMMAND_CLEAR_CACHE = 1001
     val COMMAND_CLEAR_HISTORY = 1002
+    val COMMAND_CLEAR_COOKIES = 1003
 
     fun getCommandsMap(): Map<String, Int>? {
       return MapBuilder.builder<String, Int>()
@@ -310,6 +311,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
         .put("clearFormData", COMMAND_CLEAR_FORM_DATA)
         .put("clearCache", COMMAND_CLEAR_CACHE)
         .put("clearHistory", COMMAND_CLEAR_HISTORY)
+        .put("clearCookies", COMMAND_CLEAR_COOKIES)
         .build()
     }
 
@@ -352,6 +354,10 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
           webView.clearCache(includeDiskFiles)
         }
         "clearHistory" -> webView.clearHistory()
+        "clearCookies" -> {
+          CookieManager.getInstance().removeAllCookies(null)
+          CookieManager.getInstance().flush()
+        }
       }
     }
 

--- a/apps/expo-go/modules/react-native-webview/apple/RNCWebViewImpl.m
+++ b/apps/expo-go/modules/react-native-webview/apple/RNCWebViewImpl.m
@@ -1665,6 +1665,23 @@ didFinishNavigation:(WKNavigation *)navigation
   [self removeData:dataTypes];
 }
 
+- (void)clearCookies
+{
+  if (@available(iOS 11.0, *)) {
+    [_webView.configuration.websiteDataStore.httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+      for (NSHTTPCookie *cookie in cookies) {
+        [_webView.configuration.websiteDataStore.httpCookieStore deleteCookie:cookie completionHandler:^{}];
+      }
+    }];
+  } else {
+    // Fallback for iOS versions < 11.0
+    NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookies];
+    for (NSHTTPCookie *cookie in cookies) {
+      [[NSHTTPCookieStorage sharedHTTPCookieStorage] deleteCookie:cookie];
+    }
+  }
+}
+
 - (void)removeData:(NSSet *)dataTypes
 {
   if (_webView == nil) {

--- a/apps/expo-go/modules/react-native-webview/src/WebView.android.tsx
+++ b/apps/expo-go/modules/react-native-webview/src/WebView.android.tsx
@@ -179,6 +179,8 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(
           Commands.clearCache(webViewRef.current, includeDiskFiles),
         clearHistory: () =>
           webViewRef.current && Commands.clearHistory(webViewRef.current),
+        clearCookies: () =>
+          webViewRef.current && Commands.clearCookies(webViewRef.current),
       }),
       [setViewState, webViewRef]
     );

--- a/apps/expo-go/modules/react-native-webview/src/WebView.ios.tsx
+++ b/apps/expo-go/modules/react-native-webview/src/WebView.ios.tsx
@@ -159,6 +159,8 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(
         clearCache: (includeDiskFiles: boolean) =>
           webViewRef.current &&
           Commands.clearCache(webViewRef.current, includeDiskFiles),
+        clearCookies: () =>
+          webViewRef.current && Commands.clearCookies(webViewRef.current),
       }),
       [setViewState, webViewRef]
     );

--- a/apps/expo-go/modules/react-native-webview/src/WebView.macos.tsx
+++ b/apps/expo-go/modules/react-native-webview/src/WebView.macos.tsx
@@ -126,6 +126,8 @@ const WebViewComponent = forwardRef<{}, MacOSWebViewProps>(
           Commands.injectJavaScript(webViewRef.current, data),
         requestFocus: () =>
           webViewRef.current && Commands.requestFocus(webViewRef.current),
+        clearCookies: () =>
+          webViewRef.current && Commands.clearCookies(webViewRef.current),
       }),
       [setViewState, webViewRef]
     );

--- a/apps/expo-go/modules/react-native-webview/src/WebView.windows.tsx
+++ b/apps/expo-go/modules/react-native-webview/src/WebView.windows.tsx
@@ -39,6 +39,7 @@ const Commands = codegenNativeCommands({
     'injectJavaScript',
     'requestFocus',
     'clearCache',
+    'clearCookies',
     'postMessage',
     'loadUrl',
   ],
@@ -142,6 +143,7 @@ const WebViewComponent = forwardRef<{}, WindowsWebViewProps>(
           Commands.injectJavaScript(webViewRef.current, data),
         requestFocus: () => Commands.requestFocus(webViewRef.current),
         clearCache: () => Commands.clearCache(webViewRef.current),
+        clearCookies: () => Commands.clearCookies(webViewRef.current),
         loadUrl: (url: string) => Commands.loadUrl(webViewRef.current, url),
       }),
       [setViewState, webViewRef]

--- a/apps/expo-go/modules/react-native-webview/src/WebViewTypes.ts
+++ b/apps/expo-go/modules/react-native-webview/src/WebViewTypes.ts
@@ -20,7 +20,8 @@ type WebViewCommands =
   | 'injectJavaScript'
   | 'loadUrl'
   | 'requestFocus'
-  | 'clearCache';
+  | 'clearCache'
+  | 'clearCookies';
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearFormData';
 

--- a/apps/expo-go/modules/react-native-webview/windows/ReactNativeWebView/ReactWebView2Manager.cpp
+++ b/apps/expo-go/modules/react-native-webview/windows/ReactNativeWebView/ReactWebView2Manager.cpp
@@ -144,6 +144,7 @@ namespace winrt::ReactNativeWebView::implementation {
         commands.Append(L"injectJavaScript");
         commands.Append(L"requestFocus");
         commands.Append(L"clearCache");
+        commands.Append(L"clearCookies");
         commands.Append(L"postMessage");
         commands.Append(L"loadUrl");
         return commands.GetView();
@@ -185,6 +186,10 @@ namespace winrt::ReactNativeWebView::implementation {
         else if (commandId == L"clearCache") {
             // There is no way to clear the cache in WebView2 because it is shared with Edge.
             // The best we can do is clear the cookies, because we cannot access history or local storage.
+            auto cookieManager = webView.CoreWebView2().CookieManager();
+            cookieManager.DeleteAllCookies();
+        }
+        else if (commandId == L"clearCookies") {
             auto cookieManager = webView.CoreWebView2().CookieManager();
             cookieManager.DeleteAllCookies();
         }


### PR DESCRIPTION
Add `clearCookies` method to WebView to allow programmatic clearing of cookies.

This new command provides a consistent API across Android, iOS, macOS, and Windows, utilizing each platform's native cookie management capabilities.